### PR TITLE
Fix a bug that an URL with multibyte characters isn't shown

### DIFF
--- a/lib/redmine/wiki_formatting/common_mark/formatter.rb
+++ b/lib/redmine/wiki_formatting/common_mark/formatter.rb
@@ -9,13 +9,14 @@ module Redmine
         include Redmine::Helpers::URL
 
         def link(node)
-          return unless uri_with_safe_scheme?(node.url)
+          url = escape_href(node.url)
+          return unless uri_with_safe_scheme?(url)
 
-          out('<a href="', node.url.nil? ? '' : escape_href(node.url), '"')
+          out('<a href="', url.nil? ? '' : url, '"')
           if node.title && !node.title.empty?
             out(' title="', escape_html(node.title), '"')
           end
-          unless node.url && node.url.start_with?("/")
+          unless url && url.start_with?("/")
             out(' class="external"')
           end
           out('>', :children, '</a>')

--- a/test/unit/common_mark_test.rb
+++ b/test/unit/common_mark_test.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Redmine - project management software
 # Copyright (C) 2006-2017  Jean-Philippe Lang
 #
@@ -88,6 +89,18 @@ STR
   def test_locals_links_should_not_have_external_css_class
     text = 'This is a [link](/issues)'
     assert_equal '<p>This is a <a href="/issues">link</a></p>', @formatter.new(text).to_html.strip
+  end
+
+  def test_url
+    text = 'http://www.example.com: example'
+    assert_equal '<p><a href="http://www.example.com" class="external">http://www.example.com</a>: example</p>',
+                 @formatter.new(text).to_html.strip
+  end
+
+  def test_url_with_multibyte
+    text = 'http://www.example.com/ほげ: はげ'
+    assert_equal '<p><a href="http://www.example.com/%E3%81%BB%E3%81%92" class="external">http://www.example.com/ほげ</a>: はげ</p>',
+                 @formatter.new(text).to_html.strip
   end
 
   end


### PR DESCRIPTION
コメントに以下のようなURLを入れると、該当テキスト・リンクが表示されない問題を修正します。

```
http://www.example.com/ほげ
```
