### PR TITLE
Correct version specifier for commonmarker in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-gem "commonmarker", "=> 0.18.1"
+gem "commonmarker", ">= 0.18.1"


### PR DESCRIPTION
Fix the following error.

```
[!] There was an error parsing `Gemfile`: Illformed requirement ["=> 0.18.1"]. Bundler cannot continue.

 #  from /usr/src/redmine/plugins/redmine_common_mark/Gemfile:1
 #  -------------------------------------------
 >  gem "commonmarker", "=> 0.18.1"
 #  -------------------------------------------
. Bundler cannot continue.
```