### PR TITLE
Make it possible to disable settings that are enabled by default

### DIFF
--- a/app/views/settings/_field.html.erb
+++ b/app/views/settings/_field.html.erb
@@ -2,6 +2,6 @@
 <p>
   <%= label_tag do %>
     <%= key %>
-    <%= check_box_tag("settings[#{name}]", "1", settings.present? && settings[name] == "1") %>
+    <%= check_box("settings", name, { :checked => settings.present? && settings[name] == "1" }) %>
   <% end -%>
 </p>


### PR DESCRIPTION
With `check_box_tag`, disabled settings are not stored in DB. So settings
enabled by default are not disabled after merge. For example, "table" extension cannot be disabled.

Using `check_box` solves the problem since value "0" is stored for disable
settings.

Sample DB contents when using `check_box_tag`. (Stored only enabled settings)
```
redmine=# select * from settings where name = 'plugin_common_mark';
 id |        name        |                          value                          |         updated_on
----+--------------------+---------------------------------------------------------+----------------------------
  1 | plugin_common_mark | --- !ruby/hash:ActiveSupport::HashWithIndifferentAccess+| 2019-05-30 14:59:20.755801
    |                    | render_hardbreaks: '1'                                 +|
    |                    | extension_tasklist: '1'                                +|
    |                    |
```

Sample DB contents when using `check_box`
```
redmine=# select * from settings where name = 'plugin_common_mark';
 id |        name        |                          value                          |         updated_on
----+--------------------+---------------------------------------------------------+----------------------------
  1 | plugin_common_mark | --- !ruby/hash:ActiveSupport::HashWithIndifferentAccess+| 2019-05-30 15:30:07.629444
    |                    | parse_validate_utf8: '0'                               +|
    |                    | parse_smart: '0'                                       +|
    |                    | parse_liberal_html_tag: '0'                            +|
    |                    | parse_footnotes: '0'                                   +|
    |                    | parse_strikethrough_double_tilde: '0'                  +|
    |                    | parse_unsafe: '0'                                      +|
    |                    | render_sourcepos: '0'                                  +|
    |                    | render_hardbreaks: '1'                                 +|
    |                    | render_nobreaks: '0'                                   +|
    |                    | render_github_pre_lang: '0'                            +|
    |                    | render_table_prefer_style_attributes: '0'              +|
    |                    | render_full_info_string: '0'                           +|
    |                    | render_unsafe: '0'                                     +|
    |                    | extension_table: '1'                                   +|
    |                    | extension_strikethrough: '1'                           +|
    |                    | extension_autolink: '0'                                +|
    |                    | extension_tagfilter: '1'                               +|
    |                    | extension_tasklist: '1'                                +|
    |                    |                                                         |
```