### PR TITLE
Explicitly support tasklist extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-gem "commonmarker", ">= 0.18.1"
+gem "commonmarker", ">= 0.19.0"

--- a/init.rb
+++ b/init.rb
@@ -25,7 +25,8 @@ Redmine::Plugin.register :common_mark do
              extension_table: "1",
              extension_strikethrough: "1",
              extension_autolink: "1",
-             extension_tagfilter: "1"
+             extension_tagfilter: "1",
+             extension_tasklist: "1"
            }, partial: "settings/common_mark"
 end
 


### PR DESCRIPTION
I found I can use `tasklist` extension with the current `redmine_common_mark` if `commonmarker` gem is up-to-date. It is so nice!

I think it is better to support it explicitly.

Tasklist is supported since CommonMarker [v0.19.0](https://github.com/gjtorikian/commonmarker/releases/tag/v0.19.0).